### PR TITLE
fix(): Corrigindo falha de segurança na lib de logs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,4 +5,4 @@ if [[ ! -z "${APP_STAGE}" ]]; then
     eval $(curl -s env.getter/${APP_NAME}?format=bash)
 fi
 
-exec java $@ -jar /app.jar
+exec java $@ -jar /app.jar -Dlog4j2.formatMsgNoLookups=true


### PR DESCRIPTION
Isso sana a vunerabilidade para quem estiver utilizando a lib da versão 2.10 para cima. Os outros caso de lib abaixo dessa versão seram sanados somente com a atualização da lib. Em breve com o lançamento da versões atualizada tando da lib sl4j-core e lombook estaremos adicionando uma nova regra obrigando todos repositorios a terem essas libs nas ultimas versões disponíveis. Conto com a compreensão de todos para evitarmos problemas futuros de vunerabilidades.